### PR TITLE
Remove usages of Data.Tuple.Nested.

### DIFF
--- a/src/CSS/Animation.purs
+++ b/src/CSS/Animation.purs
@@ -8,7 +8,7 @@ import CSS.Time (Time)
 import CSS.Transition (TimingFunction)
 import Data.Foldable (for_)
 import Data.Generic (class Generic)
-import Data.Tuple.Nested (tuple7)
+import Data.Tuple (Tuple(Tuple))
 
 newtype AnimationDirection = AnimationDirection Value
 
@@ -72,6 +72,7 @@ animation p de f du i di fm = do
     , "-moz-animation"
     , "-o-animation"
     ]
+  tuple7 a b c d e f g = Tuple a ( Tuple b (Tuple c (Tuple d (Tuple e (Tuple f g)))))
 
 newtype AnimationName = AnimationName Value
 

--- a/src/CSS/Border.purs
+++ b/src/CSS/Border.purs
@@ -1,15 +1,13 @@
 module CSS.Border where
 
 import Prelude
-
-import Data.Generic (class Generic)
-import Data.Tuple.Nested (tuple3, tuple4)
-
 import CSS.Color (Color)
 import CSS.Property (class Val, Value)
 import CSS.Size (Size, Abs)
 import CSS.String (fromString)
 import CSS.Stylesheet (CSS, key)
+import Data.Generic (class Generic)
+import Data.Tuple (Tuple(Tuple))
 
 newtype Stroke = Stroke Value
 
@@ -49,9 +47,13 @@ outset = Stroke $ fromString "outset"
 
 border :: Stroke -> Size Abs -> Color -> CSS
 border a b c = key (fromString "border") $ tuple3 a b c
+  where
+  tuple3 a b c = Tuple a (Tuple b c)
 
 borderColor :: Color -> CSS
 borderColor = key $ fromString "border-color"
 
 borderRadius :: forall a. Size a -> Size a -> Size a -> Size a -> CSS
 borderRadius a b c d = key (fromString "border-radius") (tuple4 a b c d)
+  where
+  tuple4 a b c d = Tuple a (Tuple b (Tuple c d))

--- a/src/CSS/Geometry.purs
+++ b/src/CSS/Geometry.purs
@@ -1,11 +1,10 @@
 module CSS.Geometry where
 
-import Data.Function (($))
-import Data.Tuple.Nested (tuple4)
-
 import CSS.Size (Size)
 import CSS.String (fromString)
 import CSS.Stylesheet (CSS, key)
+import Data.Function (($))
+import Data.Tuple (Tuple(Tuple))
 
 width :: forall a. Size a -> CSS
 width = key $ fromString "width"
@@ -39,6 +38,8 @@ right = key $ fromString "right"
 
 padding :: forall a. Size a -> Size a -> Size a -> Size a -> CSS
 padding a b c d = key (fromString "padding") $ tuple4 a b c d
+  where
+  tuple4 a b c d = Tuple a (Tuple b (Tuple c d))
 
 paddingTop :: forall a. Size a -> CSS
 paddingTop = key $ fromString "padding-top"
@@ -54,6 +55,8 @@ paddingRight = key $ fromString "padding-right"
 
 margin :: forall a. Size a -> Size a -> Size a -> Size a -> CSS
 margin a b c d = key (fromString "margin") $ tuple4 a b c d
+  where
+  tuple4 a b c d = Tuple a (Tuple b (Tuple c d))
 
 marginTop :: forall a. Size a -> CSS
 marginTop = key $ fromString "margin-top"

--- a/src/CSS/Property.purs
+++ b/src/CSS/Property.purs
@@ -87,8 +87,6 @@ instance valString :: Val String where
 instance valUnit :: Val Unit where
   value u = fromString ""
 
--- When `b` is Unit, the rendered value will have an extra
---   space appended to end. Shouldn't hurt. I'd fix if I knew how.
 instance valTuple :: (Val a, Val b) => Val (Tuple a b) where
   value (Tuple a b) = value a <> fromString " " <> value b
 

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -50,7 +50,7 @@ main :: Eff (err :: EXCEPTION) Unit
 main = do
   renderedInline example1 `assertEqual` Just "color: hsl(0.0, 100.0%, 50.0%); display: block"
   renderedInline example2 `assertEqual` Just "display: inline-block"
-  renderedInline example3 `assertEqual` Just "border: dashed 2.0px hsl(240.0, 100.0%, 50.0%) "
+  renderedInline example3 `assertEqual` Just "border: dashed 2.0px hsl(240.0, 100.0%, 50.0%)"
 
   selector (Selector (Refinement [Id "test"]) Star) `assertEqual` "#test"
 


### PR DESCRIPTION
Data.Tuple.Nested moved to meaning extensible tuples, which
implies ending the Tuple in Unit. This added Unit causes an extra
space to be added to a tuple-backed CSS rule, like animation.
In addition, we aren't using tuple-combinators, which extensible
tuples enables.

See discussion: https://github.com/slamdata/purescript-css/pull/43#issuecomment-257904343

Note that this patch isn't DRY - I reimplemented tuple4 several times. What's the preferred way to handle that?