### PR TITLE
Add roles declarations to forbid unsafe coercions

### DIFF
--- a/src/CSS/Property.purs
+++ b/src/CSS/Property.purs
@@ -40,6 +40,8 @@ quote s = "\"" <> s <> "\""
 newtype Key :: Type -> Type
 newtype Key a = Key Prefixed
 
+type role Key representational
+
 derive instance eqKey :: (Eq a) => Eq (Key a)
 derive instance ordKey :: (Ord a) => Ord (Key a)
 

--- a/src/CSS/Size.purs
+++ b/src/CSS/Size.purs
@@ -9,6 +9,8 @@ import CSS.String (class IsString, fromString)
 newtype Size :: Type -> Type
 newtype Size a = Size Value
 
+type role Size nominal
+
 derive instance eqSize :: Eq a => Eq (Size a)
 derive instance ordSize :: Ord a => Ord (Size a)
 
@@ -80,6 +82,8 @@ data Rad
 
 newtype Angle :: Type -> Type
 newtype Angle a = Angle Value
+
+type role Angle nominal
 
 derive instance eqAngle :: Eq a => Eq (Angle a)
 derive instance ordAngle :: Ord a => Ord (Angle a)


### PR DESCRIPTION
This allows terms of type `Key a` to be coerced to type `Key b` when `Coercible a b` holds but prevents terms of type `Size a` and `Angle a` to be coerced to type `Size b` and `Angle b`. The reasoning being that keys of some type can be associated to to terms of types with the same representation but not arbitrary types and values with absolute or relative sizes and angles in degrees or radians don’t describe the same runtime values.