### PR TITLE
Remove the dependency on generics-rep

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,14 +21,13 @@
     "tests"
   ],
   "dependencies": {
-    "purescript-generics-rep": "master",
+    "purescript-colors": "master",
+    "purescript-console": "master",
     "purescript-nonempty": "master",
     "purescript-profunctor": "master",
     "purescript-strings": "master",
     "purescript-these": "main",
-    "purescript-transformers": "master",
-    "purescript-colors": "master",
-    "purescript-console": "master"
+    "purescript-transformers": "master"
   },
   "devDependencies": {
     "purescript-exceptions": "master"

--- a/spago.dhall
+++ b/spago.dhall
@@ -4,7 +4,6 @@
   , "console"
   , "effect"
   , "exceptions"
-  , "generics-rep"
   , "nonempty"
   , "profunctor"
   , "psci-support"


### PR DESCRIPTION
**Description of the change**
Generic instances were removed in https://github.com/purescript-contrib/purescript-css/pull/76 but generics-rep was still listed in the bower.json and the spago.dhall files, this seems to be an oversight.