### PR TITLE
Introduce purs-tidy formatter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
 
       - name: Set up a PureScript toolchain
         uses: purescript-contrib/setup-purescript@main
+        with:
+          purs-tidy: "latest"
 
       - name: Cache PureScript dependencies
         uses: actions/cache@v2
@@ -32,3 +34,6 @@ jobs:
 
       - name: Run tests
         run: spago test --no-install
+
+      - name: Check formatting
+        run: purs-tidy check src test

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 !.gitignore
 !.github
 !.editorconfig
+!.tidyrc.json
 
 output
 generated-docs

--- a/.tidyrc.json
+++ b/.tidyrc.json
@@ -1,0 +1,10 @@
+{
+  "importSort": "source",
+  "importWrap": "source",
+  "indent": 2,
+  "operatorsFile": null,
+  "ribbon": 1,
+  "typeArrowPlacement": "first",
+  "unicode": "never",
+  "width": null
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ New features:
 Bugfixes:
 
 Other improvements:
+- Added `purs-tidy` formatter (#138 by @thomashoneyman)
 - Remove ending space in css output (e.g. `padding: 1 2 3 4 `) (#135 by @chexxor and @JordanMartinez)
 
 ## [v5.0.1](https://github.com/purescript-contrib/purescript-css/releases/tag/v5.0.1) - 2021-04-19

--- a/packages.dhall
+++ b/packages.dhall
@@ -1,4 +1,4 @@
 let upstream =
-      https://github.com/purescript/package-sets/releases/download/psc-0.14.3-20210722/packages.dhall sha256:1ceb43aa59436bf5601bac45f6f3781c4e1f0e4c2b8458105b018e5ed8c30f8c
+      https://github.com/purescript/package-sets/releases/download/psc-0.14.5-20211116/packages.dhall sha256:7ba810597a275e43c83411d2ab0d4b3c54d0b551436f4b1632e9ff3eb62e327a
 
 in  upstream

--- a/src/CSS/Background.purs
+++ b/src/CSS/Background.purs
@@ -1,6 +1,6 @@
 module CSS.Background
   (
-  -- * Generic background property.
+    -- * Generic background property.
     class Background
   , background
 
@@ -18,16 +18,21 @@ module CSS.Background
   , BackgroundSize
   , backgroundSize
   , backgroundSizes
-  , contain, cover
+  , contain
+  , cover
   , by
 
   -- * The background-repeat.
   , BackgroundRepeat
   , backgroundRepeat
   , backgroundRepeats
-  , repeat, space, round, noRepeat
+  , repeat
+  , space
+  , round
+  , noRepeat
   , xyRepeat
-  , repeatX, repeatY
+  , repeatX
+  , repeatY
 
   -- * The background-origin.
   , BackgroundOrigin
@@ -45,7 +50,8 @@ module CSS.Background
   , BackgroundAttachment
   , backgroundAttachment
   , backgroundAttachments
-  , attachFixed, attachScroll
+  , attachFixed
+  , attachScroll
 
   -- * The background-image.
   , BackgroundImage
@@ -70,8 +76,7 @@ module CSS.Background
   , Location
   , class Loc
   , location
-  )
-where
+  ) where
 
 import Prelude
 
@@ -95,8 +100,7 @@ class Val a <= Background a where
 instance backgroundArray :: (Background a) => Background (Array a) where
   background = key $ fromString "background"
 
-instance backgroundTuple
-  :: (Background a, Background b) => Background (Tuple a b) where
+instance backgroundTuple :: (Background a, Background b) => Background (Tuple a b) where
   background = key $ fromString "background"
 
 instance backgroundColor' :: Background Color where
@@ -118,7 +122,8 @@ instance backgroundBackgroundClip :: Background BackgroundClip where
   background = key $ fromString "background"
 
 instance backgroundBackgroundAttachment :: Background BackgroundAttachment
-  where background = key $ fromString "background"
+  where
+  background = key $ fromString "background"
 
 instance backgroundBackgroundImage :: Background BackgroundImage where
   background = key $ fromString "background"

--- a/src/CSS/Box.purs
+++ b/src/CSS/Box.purs
@@ -1,11 +1,12 @@
 module CSS.Box
   ( BoxType
-  , paddingBox, borderBox, contentBox
+  , paddingBox
+  , borderBox
+  , contentBox
   , boxSizing
   , boxShadow
   , insetBoxShadow
-  )
-where
+  ) where
 
 import Prelude
 
@@ -56,6 +57,6 @@ boxShadow x y w c =
 
 -------------------------------------------------------------------------------
 
-insetBoxShadow ::
-  forall a. Stroke -> Size a -> Size a -> Size a -> Color -> CSS
+insetBoxShadow
+  :: forall a. Stroke -> Size a -> Size a -> Size a -> Color -> CSS
 insetBoxShadow x y w c z = prefixed (browsers <> fromString "box-shadow") (x ! y ! w ! c ! z)

--- a/src/CSS/Box.purs
+++ b/src/CSS/Box.purs
@@ -57,6 +57,5 @@ boxShadow x y w c =
 
 -------------------------------------------------------------------------------
 
-insetBoxShadow
-  :: forall a. Stroke -> Size a -> Size a -> Size a -> Color -> CSS
+insetBoxShadow :: forall a. Stroke -> Size a -> Size a -> Size a -> Color -> CSS
 insetBoxShadow x y w c z = prefixed (browsers <> fromString "box-shadow") (x ! y ! w ! c ! z)

--- a/src/CSS/Common.purs
+++ b/src/CSS/Common.purs
@@ -12,53 +12,114 @@ import Data.Tuple (Tuple(..))
 import CSS.Property (Prefixed(..), Value)
 import CSS.String (class IsString, fromString)
 
-class All      a where all      :: a
-class Auto     a where auto     :: a
-class Baseline a where baseline :: a
-class Center   a where center   :: a
-class Inherit  a where inherit  :: a
-class None     a where none     :: a
-class Normal   a where normal   :: a
-class Visible  a where visible  :: a
-class Hidden   a where hidden   :: a
-class Initial  a where initial  :: a
-class Unset    a where unset    :: a
-class Top      a where top      :: a
-class Middle   a where middle   :: a
-class Bottom   a where bottom   :: a
-class URL      a where url      :: String -> a
+class All a where
+  all :: a
+
+class Auto a where
+  auto :: a
+
+class Baseline a where
+  baseline :: a
+
+class Center a where
+  center :: a
+
+class Inherit a where
+  inherit :: a
+
+class None a where
+  none :: a
+
+class Normal a where
+  normal :: a
+
+class Visible a where
+  visible :: a
+
+class Hidden a where
+  hidden :: a
+
+class Initial a where
+  initial :: a
+
+class Unset a where
+  unset :: a
+
+class Top a where
+  top :: a
+
+class Middle a where
+  middle :: a
+
+class Bottom a where
+  bottom :: a
+
+class URL a where
+  url :: String -> a
 
 -- | The other type class is used to escape from the type safety introduced by
 -- | embedding CSS properties into the typed world of purescript-css.
 -- | `Other` allows you to cast any `Value` to a specific value type.
-class Other a where other :: Value -> a
+class Other a where
+  other :: Value -> a
 
-instance allValue      :: All      Value where all      = fromString "all"
-instance autoValue     :: Auto     Value where auto     = fromString "auto"
-instance baselineValue :: Baseline Value where baseline = fromString "baseline"
-instance centerValue   :: Center   Value where center   = fromString "center"
-instance inheritValue  :: Inherit  Value where inherit  = fromString "inherit"
-instance normalValue   :: Normal   Value where normal   = fromString "normal"
-instance noneValue     :: None     Value where none     = fromString "none"
-instance visibleValue  :: Visible  Value where visible  = fromString "visible"
-instance hiddenValue   :: Hidden   Value where hidden   = fromString "hidden"
-instance otherValue    :: Other    Value where other    = identity
-instance initialValue  :: Initial  Value where initial  = fromString "initial"
-instance unsetValue    :: Unset    Value where unset    = fromString "unset"
-instance topValue      :: Top      Value where top      = fromString "top"
-instance middleValue   :: Middle   Value where middle   = fromString "middle"
-instance bottomValue   :: Bottom   Value where bottom   = fromString "bottom"
-instance urlValue :: URL Value where url s = fromString ("url(\"" <> s <> "\")")
+instance allValue :: All Value where
+  all = fromString "all"
+
+instance autoValue :: Auto Value where
+  auto = fromString "auto"
+
+instance baselineValue :: Baseline Value where
+  baseline = fromString "baseline"
+
+instance centerValue :: Center Value where
+  center = fromString "center"
+
+instance inheritValue :: Inherit Value where
+  inherit = fromString "inherit"
+
+instance normalValue :: Normal Value where
+  normal = fromString "normal"
+
+instance noneValue :: None Value where
+  none = fromString "none"
+
+instance visibleValue :: Visible Value where
+  visible = fromString "visible"
+
+instance hiddenValue :: Hidden Value where
+  hidden = fromString "hidden"
+
+instance otherValue :: Other Value where
+  other = identity
+
+instance initialValue :: Initial Value where
+  initial = fromString "initial"
+
+instance unsetValue :: Unset Value where
+  unset = fromString "unset"
+
+instance topValue :: Top Value where
+  top = fromString "top"
+
+instance middleValue :: Middle Value where
+  middle = fromString "middle"
+
+instance bottomValue :: Bottom Value where
+  bottom = fromString "bottom"
+
+instance urlValue :: URL Value where
+  url s = fromString ("url(\"" <> s <> "\")")
 
 -- | Common list browser prefixes to make
 -- | experimental properties work in different browsers.
 browsers :: Prefixed
 browsers = Prefixed
   [ Tuple "-webkit-" ""
-  , Tuple    "-moz-" ""
-  , Tuple     "-ms-" ""
-  , Tuple      "-o-" ""
-  , Tuple         "" ""
+  , Tuple "-moz-" ""
+  , Tuple "-ms-" ""
+  , Tuple "-o-" ""
+  , Tuple "" ""
   ]
 
 -- | Syntax for CSS function call.

--- a/src/CSS/Cursor.purs
+++ b/src/CSS/Cursor.purs
@@ -10,7 +10,7 @@ data Cursor
   = Default
   | Help
   | Pointer
-  | Progress 
+  | Progress
   | Wait
   | Cell
   | Crosshair
@@ -19,13 +19,13 @@ data Cursor
   | Alias
   | Copy
   | Move
-  | NoDrop 
+  | NoDrop
   | NotAllowed
   | Grab
   | Grabbing
   | AllScroll
   | ColResize
-  | RowResize 
+  | RowResize
   | NResize
   | EResize
   | SResize
@@ -45,29 +45,29 @@ derive instance eqCursor :: Eq Cursor
 derive instance ordCursor :: Ord Cursor
 
 instance valCursor :: Val Cursor where
-  value Default  = fromString "default"
+  value Default = fromString "default"
   value Help = fromString "help"
-  value Pointer  = fromString "pointer"
+  value Pointer = fromString "pointer"
   value Progress = fromString "progress"
   value Wait = fromString "wait"
   value Cell = fromString "cell"
-  value Crosshair  = fromString "crosshair"
+  value Crosshair = fromString "crosshair"
   value Text = fromString "text"
   value VerticalText = fromString "vertical-text"
-  value Alias  = fromString "alias"
+  value Alias = fromString "alias"
   value Copy = fromString "copy"
   value Move = fromString "move"
   value NoDrop = fromString "no-drop"
   value NotAllowed = fromString "not-allowed"
   value Grab = fromString "grab"
   value Grabbing = fromString "grabbing"
-  value AllScroll  = fromString "all-scroll"
-  value ColResize  = fromString "col-resize"
-  value RowResize  = fromString "row-resize"
-  value NResize  = fromString "n-resize"
-  value EResize  = fromString "e-resize"
-  value SResize  = fromString "s-resize"
-  value WResize  = fromString "w-resize"
+  value AllScroll = fromString "all-scroll"
+  value ColResize = fromString "col-resize"
+  value RowResize = fromString "row-resize"
+  value NResize = fromString "n-resize"
+  value EResize = fromString "e-resize"
+  value SResize = fromString "s-resize"
+  value WResize = fromString "w-resize"
   value NEResize = fromString "ne-resize"
   value NWResize = fromString "nw-resize"
   value SEResize = fromString "se-resize"
@@ -77,7 +77,7 @@ instance valCursor :: Val Cursor where
   value NESWResize = fromString "nesw-resize"
   value NWSEResize = fromString "nwse-resize"
   value ZoomIn = fromString "zoom-in"
-  value ZoomOut  = fromString "zoom-out"
+  value ZoomOut = fromString "zoom-out"
 
 cursor :: Cursor -> CSS
 cursor = key $ fromString "cursor"

--- a/src/CSS/Flexbox.purs
+++ b/src/CSS/Flexbox.purs
@@ -264,12 +264,10 @@ instance flexEndJustifyContentValue :: FlexEnd JustifyContentValue where
 instance flexStartJustifyContentValue :: FlexStart JustifyContentValue where
   flexStart = fromString "flex-start"
 
-instance spaceAroundJustifyContentValue :: SpaceAround JustifyContentValue
-  where
+instance spaceAroundJustifyContentValue :: SpaceAround JustifyContentValue where
   spaceAround = fromString "space-around"
 
-instance spaceBetweenJustifyContentValue :: SpaceBetween JustifyContentValue
-  where
+instance spaceBetweenJustifyContentValue :: SpaceBetween JustifyContentValue where
   spaceBetween = fromString "space-between"
 
 justifyContent :: JustifyContentValue -> CSS

--- a/src/CSS/Flexbox.purs
+++ b/src/CSS/Flexbox.purs
@@ -161,8 +161,9 @@ alignSelf = key $ fromString "align-self"
 
 flex :: forall b. Number -> Number -> Size b -> CSS
 flex g s b = key (fromString "flex") (gs ! ss ! value b)
-  where gs = fromString (show g) :: Value
-        ss = fromString (show s) :: Value
+  where
+  gs = fromString (show g) :: Value
+  ss = fromString (show s) :: Value
 
 -------------------------------------------------------------------------------
 
@@ -207,7 +208,7 @@ flexFlow d w = key (fromString "flex-flow") (d ! w)
 flexGrow :: Number -> CSS
 flexGrow i = key (fromString "flex-grow") (fromString (show i) :: Value)
 
-flexShrink :: Number  -> CSS
+flexShrink :: Number -> CSS
 flexShrink i = key (fromString "flex-shrink") (fromString (show i) :: Value)
 
 -------------------------------------------------------------------------------
@@ -264,10 +265,12 @@ instance flexStartJustifyContentValue :: FlexStart JustifyContentValue where
   flexStart = fromString "flex-start"
 
 instance spaceAroundJustifyContentValue :: SpaceAround JustifyContentValue
-  where spaceAround = fromString "space-around"
+  where
+  spaceAround = fromString "space-around"
 
 instance spaceBetweenJustifyContentValue :: SpaceBetween JustifyContentValue
-  where spaceBetween = fromString "space-between"
+  where
+  spaceBetween = fromString "space-between"
 
 justifyContent :: JustifyContentValue -> CSS
 justifyContent = key $ fromString "justify-content"

--- a/src/CSS/Gradient.purs
+++ b/src/CSS/Gradient.purs
@@ -1,6 +1,6 @@
 module CSS.Gradient
   (
-  -- * Color ramp type.
+    -- * Color ramp type.
     Ramp
 
   -- * Linear gradients.
@@ -10,11 +10,16 @@ module CSS.Gradient
 
   -- * Radial gradients.
   , Radial
-  , circle, ellipse
-  , circular, elliptical
+  , circle
+  , ellipse
+  , circular
+  , elliptical
 
   , Extend
-  , closestSide, closestCorner, farthestSide, farthestCorner
+  , closestSide
+  , closestCorner
+  , farthestSide
+  , farthestCorner
 
   , radialGradient
 
@@ -24,8 +29,7 @@ module CSS.Gradient
   , vRepeatingGradient
   , repeatingRadialGradient
 
-  )
-where
+  ) where
 
 import Prelude
 
@@ -59,7 +63,7 @@ hGradient :: Color -> Color -> BackgroundImage
 hGradient = shortcut (linearGradient (straight sideLeft))
 
 vGradient :: Color -> Color -> BackgroundImage
-vGradient = shortcut (linearGradient (straight sideTop ))
+vGradient = shortcut (linearGradient (straight sideTop))
 
 -------------------------------------------------------------------------------
 
@@ -80,7 +84,7 @@ hRepeatingGradient :: Color -> Color -> BackgroundImage
 hRepeatingGradient = shortcut (repeatingLinearGradient (straight sideLeft))
 
 vRepeatingGradient :: Color -> Color -> BackgroundImage
-vRepeatingGradient = shortcut (repeatingLinearGradient (straight sideTop ))
+vRepeatingGradient = shortcut (repeatingLinearGradient (straight sideTop))
 
 -------------------------------------------------------------------------------
 
@@ -137,7 +141,7 @@ radialGradient d r xs = other $ Value $
   let
     rg =
       fromString "radial-gradient("
-        <> value [value d, value r, ramp xs]
+        <> value [ value d, value r, ramp xs ]
         <> fromString ")"
   in
     case rg of
@@ -149,7 +153,7 @@ repeatingRadialGradient d r xs = other $ Value $
   let
     rrg =
       fromString "repeating-radial-gradient("
-        <> value [value d, value r, ramp xs]
+        <> value [ value d, value r, ramp xs ]
         <> fromString ")"
   in
     case rrg of
@@ -161,4 +165,4 @@ ramp :: Ramp -> Value
 ramp xs = value (map (\(Tuple a b) -> value (Tuple (value a) (value b))) xs)
 
 shortcut :: (Ramp -> BackgroundImage) -> Color -> Color -> BackgroundImage
-shortcut g f t = g [(Tuple f (pct 0.0)), (Tuple t (pct 100.0))]
+shortcut g f t = g [ (Tuple f (pct 0.0)), (Tuple t (pct 100.0)) ]

--- a/src/CSS/Gradient.purs
+++ b/src/CSS/Gradient.purs
@@ -47,17 +47,16 @@ type Ramp = Array (Tuple Color (Size Rel))
 -------------------------------------------------------------------------------
 
 linearGradient :: Direction -> Ramp -> BackgroundImage
-linearGradient d xs = other $ Value $
+linearGradient d xs = other $ Value do
   let
-    lg =
+    (Value v) =
       fromString "linear-gradient("
         <> value d
         <> fromString ","
         <> ramp xs
         <> fromString ")"
-  in
-    case lg of
-      Value v -> browsers <> v
+
+  browsers <> v
 
 hGradient :: Color -> Color -> BackgroundImage
 hGradient = shortcut (linearGradient (straight sideLeft))
@@ -68,17 +67,16 @@ vGradient = shortcut (linearGradient (straight sideTop))
 -------------------------------------------------------------------------------
 
 repeatingLinearGradient :: Direction -> Ramp -> BackgroundImage
-repeatingLinearGradient d xs = other $ Value $
+repeatingLinearGradient d xs = other $ Value do
   let
-    rlg =
+    (Value v) =
       fromString "repeating-linear-gradient("
         <> value d
         <> fromString ","
         <> ramp xs
         <> fromString ")"
-  in
-    case rlg of
-      Value v -> browsers <> v
+
+  browsers <> v
 
 hRepeatingGradient :: Color -> Color -> BackgroundImage
 hRepeatingGradient = shortcut (repeatingLinearGradient (straight sideLeft))
@@ -137,27 +135,24 @@ farthestCorner = Extend $ fromString "farthest-corner"
 -------------------------------------------------------------------------------
 
 radialGradient :: forall l. Loc l => l -> Radial -> Ramp -> BackgroundImage
-radialGradient d r xs = other $ Value $
+radialGradient d r xs = other $ Value do
   let
-    rg =
+    (Value v) =
       fromString "radial-gradient("
         <> value [ value d, value r, ramp xs ]
         <> fromString ")"
-  in
-    case rg of
-      Value v -> browsers <> v
 
-repeatingRadialGradient
-  :: forall l. Loc l => l -> Radial -> Ramp -> BackgroundImage
-repeatingRadialGradient d r xs = other $ Value $
+  browsers <> v
+
+repeatingRadialGradient :: forall l. Loc l => l -> Radial -> Ramp -> BackgroundImage
+repeatingRadialGradient d r xs = other $ Value do
   let
-    rrg =
+    (Value v) =
       fromString "repeating-radial-gradient("
         <> value [ value d, value r, ramp xs ]
         <> fromString ")"
-  in
-    case rrg of
-      Value v -> browsers <> v
+
+  browsers <> v
 
 -------------------------------------------------------------------------------
 

--- a/src/CSS/Render.purs
+++ b/src/CSS/Render.purs
@@ -57,12 +57,10 @@ render :: forall a. StyleM a -> Rendered
 render = rules [] <<< runS
 
 putInline :: CSS -> Effect Unit
-putInline s =
-  log <<< fromMaybe "" <<< renderedInline <<< render $ s
+putInline s = log <<< fromMaybe "" <<< renderedInline <<< render $ s
 
 putStyleSheet :: CSS -> Effect Unit
-putStyleSheet s =
-  log <<< fromMaybe "" <<< renderedSheet <<< render $ s
+putStyleSheet s = log <<< fromMaybe "" <<< renderedSheet <<< render $ s
 
 kframe :: Keyframes -> Rendered
 kframe (Keyframes ident xs) =
@@ -70,12 +68,14 @@ kframe (Keyframes ident xs) =
   where
   renderContent =
     " " <> ident <> " { " <> intercalate " " (uncurry frame <$> xs) <> " }\n"
+
   keywords =
     [ "@keyframes"
     , "@-webkit-keyframes"
     , "@-moz-keyframes"
     , "@-o-keyframes"
     ]
+
   allKeywordsWithContent =
     fold $ map (_ <> renderContent) keywords
 
@@ -114,11 +114,9 @@ rules sel rs = topRules <> importRules <> keyframeRules <> faceRules <> nestedSh
   faces _ = Nothing
   imports (Import i) = Just i
   imports _ = Nothing
-  topRules =
-    if not null rs' then rule' sel rs'
-    else Nothing
-    where
-    rs' = mapMaybe property rs
+  topRules = do
+    let rs' = mapMaybe property rs
+    if not null rs' then rule' sel rs' else Nothing
   nestedSheets = fold $ uncurry nestedRules <$> mapMaybe nested rs
   nestedRules a = rules (a : sel)
   queryRules = foldMap (uncurry $ flip query' sel) $ mapMaybe queries rs

--- a/src/CSS/Render.purs
+++ b/src/CSS/Render.purs
@@ -81,7 +81,8 @@ kframe (Keyframes ident xs) =
 
 frame :: Number -> Array Rule -> String
 frame p rs = show p <> "% " <> "{ " <> x <> " }"
-  where x = fromMaybe "" <<< renderedInline $ rules [] rs
+  where
+  x = fromMaybe "" <<< renderedInline $ rules [] rs
 
 query' :: MediaQuery -> Array App -> Array Rule -> Rendered
 query' q sel rs = Just <<< That <<< Sheet $ mediaQuery q <> " { " <> fromMaybe "" (renderedSheet $ rules sel rs) <> " }\n"
@@ -100,37 +101,40 @@ face rs = Just <<< That <<< Sheet $ "@font-face { " <> fromMaybe "" (renderedInl
 
 rules :: Array App -> Array Rule -> Rendered
 rules sel rs = topRules <> importRules <> keyframeRules <> faceRules <> nestedSheets <> queryRules
-  where property (Property k v) = Just (Tuple k v)
-        property _              = Nothing
-        nested   (Nested a ns ) = Just (Tuple a ns)
-        nested   _              = Nothing
-        queries  (Query  q ns ) = Just (Tuple q ns)
-        queries  _              = Nothing
-        kframes  (Keyframe fs ) = Just fs
-        kframes  _              = Nothing
-        faces    (Face ns     ) = Just ns
-        faces    _              = Nothing
-        imports  (Import i    ) = Just i
-        imports  _              = Nothing
-        topRules      = if not null rs'
-                          then rule' sel rs'
-                          else Nothing
-          where rs' = mapMaybe property rs
-        nestedSheets  = fold $ uncurry nestedRules <$> mapMaybe nested rs
-        nestedRules a = rules (a : sel)
-        queryRules    = foldMap (uncurry $ flip query' sel) $ mapMaybe queries rs
-        keyframeRules = foldMap kframe $ mapMaybe kframes rs
-        faceRules     = foldMap face   $ mapMaybe faces   rs
-        importRules   = foldMap imp    $ mapMaybe imports rs
+  where
+  property (Property k v) = Just (Tuple k v)
+  property _ = Nothing
+  nested (Nested a ns) = Just (Tuple a ns)
+  nested _ = Nothing
+  queries (Query q ns) = Just (Tuple q ns)
+  queries _ = Nothing
+  kframes (Keyframe fs) = Just fs
+  kframes _ = Nothing
+  faces (Face ns) = Just ns
+  faces _ = Nothing
+  imports (Import i) = Just i
+  imports _ = Nothing
+  topRules =
+    if not null rs' then rule' sel rs'
+    else Nothing
+    where
+    rs' = mapMaybe property rs
+  nestedSheets = fold $ uncurry nestedRules <$> mapMaybe nested rs
+  nestedRules a = rules (a : sel)
+  queryRules = foldMap (uncurry $ flip query' sel) $ mapMaybe queries rs
+  keyframeRules = foldMap kframe $ mapMaybe kframes rs
+  faceRules = foldMap face $ mapMaybe faces rs
+  importRules = foldMap imp $ mapMaybe imports rs
 
 imp :: String -> Rendered
 imp t = Just <<< That <<< Sheet <<< fromString $ "@import url(" <> t <> ");\n"
 
 rule' :: forall a. Array App -> Array (Tuple (Key a) Value) -> Rendered
 rule' sel props = maybe q o $ nel sel
-  where p = props >>= collect
-        q = (This <<< Inline <<< properties <<< oneOf) <$> nel p
-        o sel' = Just <<< That <<< Sheet $ intercalate " " [selector (merger sel'), "{", properties p, "}\n"]
+  where
+  p = props >>= collect
+  q = (This <<< Inline <<< properties <<< oneOf) <$> nel p
+  o sel' = Just <<< That <<< Sheet $ intercalate " " [ selector (merger sel'), "{", properties p, "}\n" ]
 
 selector :: Selector -> String
 selector = intercalate ", " <<< selector'
@@ -139,9 +143,9 @@ selector' :: Selector -> Array String
 selector' (Selector (Refinement ft) p) = (_ <> (foldMap predicate (sort ft))) <$> selector'' ft p
 
 selector'' :: Array Predicate -> Path Selector -> Array String
-selector'' [] Star = ["*"]
-selector'' _  Star = [""]
-selector'' _ (Elem t) = [t]
+selector'' [] Star = [ "*" ]
+selector'' _ Star = [ "" ]
+selector'' _ (Elem t) = [ t ]
 selector'' _ (PathChild a b) = sepWith " > " <$> selector' a <*> selector' b
 selector'' _ (Deep a b) = sepWith " " <$> selector' a <*> selector' b
 selector'' _ (Adjacent a b) = sepWith " + " <$> selector' a <*> selector' b
@@ -154,36 +158,37 @@ collect :: forall a. Tuple (Key a) Value -> Array (Either String (Tuple String S
 collect (Tuple (Key ky) (Value v1)) = collect' ky v1
 
 collect' :: Prefixed -> Prefixed -> Array (Either String (Tuple String String))
-collect' (Plain k) (Plain v) = [Right (Tuple k v)]
+collect' (Plain k) (Plain v) = [ Right (Tuple k v) ]
 collect' (Prefixed ks) (Plain v) = (\(Tuple p k) -> Right $ Tuple (p <> k) v) <$> ks
 collect' (Plain k) (Prefixed vs) = (\(Tuple p v) -> Right $ Tuple k (p <> v)) <$> vs
 collect' (Prefixed ks) (Prefixed vs) = (\(Tuple p k) -> maybe (Left (p <> k)) (Right <<< Tuple (p <> k) <<< (p <> _)) $ lookup p vs) <$> ks
 
 properties :: Array (Either String (Tuple String String)) -> String
-properties xs = intercalate "; " $  sheetRules <$> xs
-  where sheetRules = either (\_ -> mempty) (\(Tuple k v) -> fold [k, ": ", v])
+properties xs = intercalate "; " $ sheetRules <$> xs
+  where
+  sheetRules = either (\_ -> mempty) (\(Tuple k v) -> fold [ k, ": ", v ])
 
 merger :: NonEmpty Array App -> Selector
 merger (NonEmpty x xs) =
   case x of
     Child s -> maybe s (\xs' -> merger xs' |> s) $ nel xs
-    Sub s   -> maybe s (\xs' -> merger xs' |* s) $ nel xs
-    Root s  -> maybe s (\xs' -> s |* merger xs') $ nel xs
-    Pop i   -> maybe (element "TODO") merger <<< nel <<< drop i $ x : xs
-    Self  sheetRules  -> maybe (star `with` sheetRules) (\xs' -> merger xs' `with`  sheetRules) $ nel xs
+    Sub s -> maybe s (\xs' -> merger xs' |* s) $ nel xs
+    Root s -> maybe s (\xs' -> s |* merger xs') $ nel xs
+    Pop i -> maybe (element "TODO") merger <<< nel <<< drop i $ x : xs
+    Self sheetRules -> maybe (star `with` sheetRules) (\xs' -> merger xs' `with` sheetRules) $ nel xs
 
 predicate :: Predicate -> String
-predicate (Id           a  ) = "#" <> a
-predicate (Class        a  ) = "." <> a
-predicate (Attr         a  ) = "[" <> a <> "]"
-predicate (AttrVal      a v) = "[" <> a <> "='" <> v <> "']"
-predicate (AttrBegins   a v) = "[" <> a <> "^='" <> v <> "']"
-predicate (AttrEnds     a v) = "[" <> a <> "$='" <> v <> "']"
+predicate (Id a) = "#" <> a
+predicate (Class a) = "." <> a
+predicate (Attr a) = "[" <> a <> "]"
+predicate (AttrVal a v) = "[" <> a <> "='" <> v <> "']"
+predicate (AttrBegins a v) = "[" <> a <> "^='" <> v <> "']"
+predicate (AttrEnds a v) = "[" <> a <> "$='" <> v <> "']"
 predicate (AttrContains a v) = "[" <> a <> "*='" <> v <> "']"
-predicate (AttrSpace    a v) = "[" <> a <> "~='" <> v <> "']"
-predicate (AttrHyph     a v) = "[" <> a <> "|='" <> v <> "']"
-predicate (Pseudo       a  ) = ":" <> a
-predicate (PseudoFunc   a p) = ":" <> a <> "(" <> intercalate "," p <> ")"
+predicate (AttrSpace a v) = "[" <> a <> "~='" <> v <> "']"
+predicate (AttrHyph a v) = "[" <> a <> "|='" <> v <> "']"
+predicate (Pseudo a) = ":" <> a
+predicate (PseudoFunc a p) = ":" <> a <> "(" <> intercalate "," p <> ")"
 
 nel :: forall a. Array a -> Maybe (NonEmpty Array a)
 nel [] = Nothing

--- a/src/CSS/Selector.purs
+++ b/src/CSS/Selector.purs
@@ -35,7 +35,7 @@ instance isStringRefinement :: IsString Refinement where
           "." -> Class $ drop 1 s
           ":" -> Pseudo $ drop 1 s
           "@" -> Attr $ drop 1 s
-          _   -> Attr s
+          _ -> Attr s
       ]
 
 data Path f
@@ -59,7 +59,7 @@ instance isStringSelector :: IsString Selector where
     case take 1 s of
       "#" -> Selector (byId $ drop 1 s) Star
       "." -> Selector (byClass $ drop 1 s) Star
-      _   -> Selector (Refinement []) (Elem s)
+      _ -> Selector (Refinement []) (Elem s)
 
 -- | The star selector applies to all elements.
 -- | Maps to `*` in CSS.
@@ -74,18 +74,21 @@ element e = Selector (Refinement []) (Elem e)
 -- | Maps to `sel1 sel2` in CSS.
 deep :: Selector -> Selector -> Selector
 deep a b = Selector (Refinement []) (Deep a b)
+
 infix 6 deep as |*
 
 -- | The child selector composer.
 -- | Maps to `sel1 > sel2` in CSS.
 child :: Selector -> Selector -> Selector
 child a b = Selector (Refinement []) (PathChild a b)
+
 infix 6 child as |>
 
 -- | The adjacent selector composer.
 -- | Maps to `sel1 + sel2` in CSS.
 adjacent :: Selector -> Selector -> Selector
 adjacent a b = Selector (Refinement []) (Adjacent a b)
+
 infix 6 adjacent as |+
 
 -- | The filter selector composer, adds a filter to a selector.
@@ -93,6 +96,7 @@ infix 6 adjacent as |+
 -- | depending on the filter.
 with :: Selector -> Refinement -> Selector
 with (Selector (Refinement fs) e) (Refinement ps) = Selector (Refinement (fs <> ps)) e
+
 infix 6 with as &
 
 -- | Filter elements by id.
@@ -122,34 +126,40 @@ attr = Refinement <<< pure <<< Attr
 -- | certain attribute with the specified value.
 attrVal :: String -> String -> Refinement
 attrVal a = Refinement <<< pure <<< AttrVal a
+
 infix 6 attrVal as @=
 
 -- | Filter elements based on the presence of a certain attribute that
 -- | begins with the selected value.
 attrBegins :: String -> String -> Refinement
 attrBegins a = Refinement <<< pure <<< AttrBegins a
+
 infix 6 attrBegins as ^=
 
 -- | Filter elements based on the presence of a certain attribute that
 -- | ends with the specified value.
 attrEnds :: String -> String -> Refinement
 attrEnds a = Refinement <<< pure <<< AttrEnds a
+
 infix 6 attrEnds as $=
 
 -- | Filter elements based on the presence of a certain attribute that contains
 -- | the specified value as a substring.
 attrContains :: String -> String -> Refinement
 attrContains a = Refinement <<< pure <<< AttrContains a
+
 infix 6 attrContains as *=
 
 -- | Filter elements based on the presence of a certain attribute that
 -- | have the specified value contained in a space separated list.
 attrSpace :: String -> String -> Refinement
 attrSpace a = Refinement <<< pure <<< AttrSpace a
+
 infix 6 attrSpace as ~=
 
 -- | Filter elements based on the presence of a certain attribute that
 -- | have the specified value contained in a hyphen separated list.
 attrHyph :: String -> String -> Refinement
 attrHyph a = Refinement <<< pure <<< AttrHyph a
+
 infix 6 attrHyph as |=

--- a/src/CSS/Size.purs
+++ b/src/CSS/Size.purs
@@ -31,7 +31,7 @@ nil :: forall a. Size a
 nil = Size $ fromString "0"
 
 -- | Unitless size (as recommended for line-height).
-unitless ∷ forall a. Number → Size a
+unitless :: forall a. Number -> Size a
 unitless = Size <<< value
 
 -- | Size in pixels.

--- a/src/CSS/Stylesheet.purs
+++ b/src/CSS/Stylesheet.purs
@@ -17,12 +17,12 @@ import CSS.Selector (Selector, Refinement)
 newtype MediaType = MediaType Value
 
 derive instance eqMediaType :: Eq MediaType
-derive instance ordMediaType:: Ord MediaType
+derive instance ordMediaType :: Ord MediaType
 
 data NotOrOnly = Not | Only
 
 derive instance eqNotOrOnly :: Eq NotOrOnly
-derive instance ordNotOrOnly:: Ord NotOrOnly
+derive instance ordNotOrOnly :: Ord NotOrOnly
 
 data MediaQuery = MediaQuery (Maybe NotOrOnly) MediaType (NonEmpty Array Feature)
 
@@ -94,6 +94,7 @@ prefixed :: forall a. Val a => Prefixed -> a -> CSS
 prefixed xs = key (Key xs)
 
 infixr 5 select as ?
+
 select :: Selector -> CSS -> CSS
 select sel rs = rule $ Nested (Sub sel) (runS rs)
 
@@ -104,7 +105,7 @@ keyframes :: String -> NonEmpty Array (Tuple Number CSS) -> CSS
 keyframes n xs = rule $ Keyframe (Keyframes n (second runS <$> xs))
 
 keyframesFromTo :: String -> CSS -> CSS -> CSS
-keyframesFromTo n a b = keyframes n $ Tuple 0.0 a :| [Tuple 100.0 b]
+keyframesFromTo n a b = keyframes n $ Tuple 0.0 a :| [ Tuple 100.0 b ]
 
 fontFace :: CSS -> CSS
 fontFace = rule <<< Face <<< runS

--- a/src/CSS/Text/Shadow.purs
+++ b/src/CSS/Text/Shadow.purs
@@ -8,7 +8,6 @@ import CSS.String (fromString)
 import CSS.Stylesheet (CSS, key)
 import Data.Tuple (Tuple(..))
 
-data TextShadow :: Type -> Type
 data TextShadow a
   = TextShadow (Size a) (Size a) (Size a) (Color)
   | None

--- a/src/CSS/Text/Transform.purs
+++ b/src/CSS/Text/Transform.purs
@@ -27,12 +27,12 @@ derive instance eqTextTransform :: Eq TextTransform
 derive instance ordTextTransform :: Ord TextTransform
 
 instance valTextTransform :: Val TextTransform where
-  value Uppercase  = fromString "uppercase"
-  value Lowercase  = fromString "lowercase"
+  value Uppercase = fromString "uppercase"
+  value Lowercase = fromString "lowercase"
   value Capitalize = fromString "capitalize"
-  value None       = fromString "none"
-  value Initial    = fromString "initial"
-  value Inherit    = fromString "inherit"
+  value None = fromString "none"
+  value Initial = fromString "initial"
+  value Inherit = fromString "inherit"
 
 instance showTextTransform :: Show TextTransform where
   show Uppercase = "Uppercase"

--- a/src/CSS/TextAlign.purs
+++ b/src/CSS/TextAlign.purs
@@ -9,7 +9,7 @@ import CSS.Stylesheet (CSS, key)
 newtype TextAlign = TextAlign Value
 
 derive instance eqTextAlign :: Eq TextAlign
-derive instance ordTextAlign:: Ord TextAlign
+derive instance ordTextAlign :: Ord TextAlign
 
 instance valTextAlign :: Val TextAlign where
   value (TextAlign v) = v

--- a/src/CSS/Time.purs
+++ b/src/CSS/Time.purs
@@ -8,7 +8,7 @@ import CSS.String (fromString)
 newtype Time = Time Value
 
 derive instance eqTime :: Eq Time
-derive instance ordTime:: Ord Time
+derive instance ordTime :: Ord Time
 
 instance valTime :: Val Time where
   value (Time v) = v

--- a/src/CSS/Transform.purs
+++ b/src/CSS/Transform.purs
@@ -100,43 +100,11 @@ matrix3d
   -> Number
   -> Number
   -> Transformation
-matrix3d
-  w0
-  x0
-  y0
-  z0
-  w1
-  x1
-  y1
-  z1
-  w2
-  x2
-  y2
-  z2
-  w3
-  x3
-  y3
-  z3 =
-  Transformation $ fromString "matrix3d("
-    <> value
-      [ w0
-      , x0
-      , y0
-      , z0
-      , w1
-      , x1
-      , y1
-      , z1
-      , w2
-      , x2
-      , y2
-      , z2
-      , w3
-      , x3
-      , y3
-      , z3
-      ]
-    <> fromString ")"
+matrix3d w0 x0 y0 z0 w1 x1 y1 z1 w2 x2 y2 z2 w3 x3 y3 z3 =
+  Transformation $
+    fromString "matrix3d("
+      <> value [ w0, x0, y0, z0, w1, x1, y1, z1, w2, x2, y2, z2, w3, x3, y3, z3 ]
+      <> fromString ")"
 
 data TransformOrigin :: Type -> Type
 data TransformOrigin a

--- a/src/CSS/Transform.purs
+++ b/src/CSS/Transform.purs
@@ -11,7 +11,7 @@ import Data.Tuple (Tuple(..))
 newtype Transformation = Transformation Value
 
 derive instance eqTransformation :: Eq Transformation
-derive instance ordTransformation:: Ord Transformation
+derive instance ordTransformation :: Ord Transformation
 
 instance valTransformation :: Val Transformation where
   value (Transformation v) = v
@@ -23,7 +23,7 @@ transforms :: Array Transformation -> CSS
 transforms = key (fromString "transform") <<< noCommas
 
 translate :: forall a b. Size a -> Size b -> Transformation
-translate x y = Transformation $ fromString "translate(" <> value [value x, value y] <> fromString ")"
+translate x y = Transformation $ fromString "translate(" <> value [ value x, value y ] <> fromString ")"
 
 translateX :: forall a. Size a -> Transformation
 translateX x = Transformation $ fromString "translateX(" <> value x <> fromString ")"
@@ -35,10 +35,10 @@ translateZ :: forall a. Size a -> Transformation
 translateZ z = Transformation $ fromString "translateZ(" <> value z <> fromString ")"
 
 translate3d :: forall a b c. Size a -> Size b -> Size c -> Transformation
-translate3d x y z = Transformation $ fromString "translate3d(" <> value [value x, value y, value z] <> fromString ")"
+translate3d x y z = Transformation $ fromString "translate3d(" <> value [ value x, value y, value z ] <> fromString ")"
 
 scale :: Number -> Number -> Transformation
-scale x y = Transformation $ fromString "scale(" <> value [x, y] <> fromString ")"
+scale x y = Transformation $ fromString "scale(" <> value [ x, y ] <> fromString ")"
 
 scaleX :: Number -> Transformation
 scaleX x = Transformation $ fromString "scaleX(" <> value x <> fromString ")"
@@ -50,7 +50,7 @@ scaleZ :: Number -> Transformation
 scaleZ z = Transformation $ fromString "scaleZ(" <> value z <> fromString ")"
 
 scale3d :: Number -> Number -> Number -> Transformation
-scale3d x y z = Transformation $ fromString "scale3d(" <> value [x, y, z] <> fromString ")"
+scale3d x y z = Transformation $ fromString "scale3d(" <> value [ x, y, z ] <> fromString ")"
 
 rotate :: forall a. Angle a -> Transformation
 rotate a = Transformation $ fromString "rotate(" <> value a <> fromString ")"
@@ -65,10 +65,10 @@ rotateZ :: forall a. Angle a -> Transformation
 rotateZ z = Transformation $ fromString "rotateZ(" <> value z <> fromString ")"
 
 rotate3d :: forall a. Number -> Number -> Number -> Angle a -> Transformation
-rotate3d x y z a = Transformation $ fromString "rotate3d(" <> value [value x, value y, value z, value a] <> fromString ")"
+rotate3d x y z a = Transformation $ fromString "rotate3d(" <> value [ value x, value y, value z, value a ] <> fromString ")"
 
 skew :: Number -> Number -> Transformation
-skew x y = Transformation $ fromString "skew(" <> value [x, y] <> fromString ")"
+skew x y = Transformation $ fromString "skew(" <> value [ x, y ] <> fromString ")"
 
 skewX :: Number -> Transformation
 skewX x = Transformation $ fromString "skewX(" <> value x <> fromString ")"
@@ -83,21 +83,60 @@ matrix :: Number -> Number -> Number -> Number -> Number -> Number -> Transforma
 matrix u v w x y z = Transformation $ fromString "matrix3d(" <> value [ u, v, w, x, y, z ] <> fromString ")"
 
 matrix3d
-  :: Number -> Number -> Number -> Number
-  -> Number -> Number -> Number -> Number
-  -> Number -> Number -> Number -> Number
-  -> Number -> Number -> Number -> Number
+  :: Number
+  -> Number
+  -> Number
+  -> Number
+  -> Number
+  -> Number
+  -> Number
+  -> Number
+  -> Number
+  -> Number
+  -> Number
+  -> Number
+  -> Number
+  -> Number
+  -> Number
+  -> Number
   -> Transformation
-matrix3d w0 x0 y0 z0
-         w1 x1 y1 z1
-         w2 x2 y2 z2
-         w3 x3 y3 z3 =
-  Transformation $ fromString "matrix3d(" <> value
-       [ w0, x0, y0, z0
-       , w1, x1, y1, z1
-       , w2, x2, y2, z2
-       , w3, x3, y3, z3
-       ] <> fromString ")"
+matrix3d
+  w0
+  x0
+  y0
+  z0
+  w1
+  x1
+  y1
+  z1
+  w2
+  x2
+  y2
+  z2
+  w3
+  x3
+  y3
+  z3 =
+  Transformation $ fromString "matrix3d("
+    <> value
+      [ w0
+      , x0
+      , y0
+      , z0
+      , w1
+      , x1
+      , y1
+      , z1
+      , w2
+      , x2
+      , y2
+      , z2
+      , w3
+      , x3
+      , y3
+      , z3
+      ]
+    <> fromString ")"
 
 data TransformOrigin :: Type -> Type
 data TransformOrigin a

--- a/src/CSS/Transition.purs
+++ b/src/CSS/Transition.purs
@@ -29,7 +29,7 @@ data TimingFunction
   | CubicBezier Number Number Number Number
 
 derive instance eqTimingFunction :: Eq TimingFunction
-derive instance ordTimingFunction:: Ord TimingFunction
+derive instance ordTimingFunction :: Ord TimingFunction
 
 instance valTimingFunction :: Val TimingFunction where
   value Ease = fromString "ease"
@@ -39,8 +39,8 @@ instance valTimingFunction :: Val TimingFunction where
   value Linear = fromString "linear"
   value StepStart = fromString "step-start"
   value StepEnd = fromString "step-end"
-  value (Steps n v) = fromString "steps(" <> value [fromString $ show n, value v] <> fromString ")"
-  value (CubicBezier a b c d) = fromString "cubic-bezier(" <> value [a, b, c, d] <> fromString ")"
+  value (Steps n v) = fromString "steps(" <> value [ fromString $ show n, value v ] <> fromString ")"
+  value (CubicBezier a b c d) = fromString "cubic-bezier(" <> value [ a, b, c, d ] <> fromString ")"
 
 ease :: TimingFunction
 ease = Ease

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -47,7 +47,7 @@ example7 :: Rendered
 example7 = render do
   zIndex 11
   opacity 0.5
-  
+
 example8 :: Rendered
 example8 = render do
   flex 0.14 1.0 (pct 0.0)
@@ -169,7 +169,7 @@ main = do
   renderedInline example2 `assertEqual` Just "display: inline-block"
   renderedInline example3 `assertEqual` Just "border: dashed 2.0px hsl(240.0, 100.0%, 50.0%)"
 
-  selector (Selector (Refinement [Id "test"]) Star) `assertEqual` "#test"
+  selector (Selector (Refinement [ Id "test" ]) Star) `assertEqual` "#test"
 
   selector (fromString "#test") `assertEqual` "#test"
 
@@ -189,7 +189,7 @@ main = do
   renderedInline example6 `assertEqual` Just "src: url(\"font.woff\") format(\"woff\")"
 
   renderedInline example7 `assertEqual` Just "z-index: 11; opacity: 0.5"
-  
+
   renderedInline example8 `assertEqual` Just "flex: 0.14 1.0 0.0%"
 
   renderedInline exampleFontStyle1 `assertEqual` Just "font-style: italic"


### PR DESCRIPTION

**Description of the change**
Introduces the [`purs-tidy`](https://github.com/natefaubion/purescript-tidy) formatter. This formatter is a lightly opinionated tool we use to maintain a consistent style in the contrib libraries.

We ordinarily restrict to tools provided by the `core` or `contrib` projects. This tool is not, but it was developed and is maintained by core team members, and because it's a formatter it can't block maintenance or release of this library even in the event something goes catastrophically wrong with it.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a link to this PR and your username
- [x] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation in the README and/or documentation directory
- [x] Added a test for the contribution (if applicable)
