### PR TITLE
Add support for visibility property. Resolves #146.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Breaking changes:
 New features:
 - Add smart constructors for generic font families (#68, #136 by @Unisay and @JordanMartinez)
 - Add support for `text-direction` (#83, #137 by @vyorkin and @JordanMartinez)
+- Add support for `visibility` property (#148 by @nsaunders)
 
 Bugfixes:
 

--- a/src/CSS/Display.purs
+++ b/src/CSS/Display.purs
@@ -2,7 +2,7 @@ module CSS.Display where
 
 import Prelude
 
-import CSS.Common (class Inherit, class None)
+import CSS.Common (class Auto, class Hidden, class Inherit, class Initial, class None, class Other, class Unset, class Visible)
 import CSS.Property (class Val, Value)
 import CSS.String (fromString)
 import CSS.Stylesheet (CSS, key)
@@ -185,6 +185,26 @@ clear = key (fromString "clear")
 
 opacity :: Number -> CSS
 opacity = key $ fromString "opacity"
+
+-------------------------------------------------------------------------------
+
+newtype Visibility = Visibility Value
+
+derive newtype instance Val Visibility
+derive newtype instance Other Visibility
+derive newtype instance Inherit Visibility
+derive newtype instance Initial Visibility
+derive newtype instance Unset Visibility
+derive newtype instance Hidden Visibility
+derive newtype instance Visible Visibility
+
+collapse :: Visibility
+collapse = Visibility $ fromString "collapse"
+
+visibility :: Visibility -> CSS
+visibility = key $ fromString "visibility"
+
+-------------------------------------------------------------------------------
 
 zIndex :: Int -> CSS
 zIndex = key (fromString "z-index") <<< show

--- a/src/CSS/Display.purs
+++ b/src/CSS/Display.purs
@@ -2,7 +2,7 @@ module CSS.Display where
 
 import Prelude
 
-import CSS.Common (class Auto, class Hidden, class Inherit, class Initial, class None, class Other, class Unset, class Visible)
+import CSS.Common (class Hidden, class Inherit, class Initial, class None, class Other, class Unset, class Visible)
 import CSS.Property (class Val, Value)
 import CSS.String (fromString)
 import CSS.Stylesheet (CSS, key)

--- a/test/CSS/DisplaySpec.purs
+++ b/test/CSS/DisplaySpec.purs
@@ -1,0 +1,35 @@
+module CSS.DisplaySpec where
+
+import Prelude
+
+import CSS.Color (green)
+import CSS.Color as Color
+import CSS.Common (hidden, inherit, initial, unset, visible)
+import CSS.Display (collapse, visibility)
+import CSS.Size (em, px)
+import Common (shouldRenderFrom)
+import Data.Maybe (fromJust)
+import Data.Traversable (traverse_)
+import Data.Tuple.Nested ((/\))
+import Partial.Unsafe (unsafePartial)
+import Test.Spec (Spec, describe)
+
+spec :: Spec Unit
+spec = do
+
+  describe "visibility (Mozilla examples)" do
+    let testVisibility (s /\ v) = ("visibility: " <> s) `shouldRenderFrom` visibility v
+    describe "Keyword values" $
+      traverse_
+        testVisibility
+        [ "visible" /\ visible
+        , "hidden" /\ hidden
+        , "collapse" /\ collapse
+        ]
+    describe "Global values" $
+      traverse_
+        testVisibility
+        [ "inherit" /\ inherit
+        , "initial" /\ initial
+        , "unset" /\ unset
+        ]

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -4,6 +4,7 @@ import Prelude
 
 import CSS (Rendered, Path(..), Predicate(..), Refinement(..), Selector(..), FontFaceSrc(..), FontFaceFormat(..), pct, renderedSheet, renderedInline, fromString, selector, block, display, render, borderBox, boxSizing, contentBox, blue, color, body, a, p, px, dashed, border, inlineBlock, red, gold, teal, olive, black, (?), (&), (|>), (|*), (|+), byId, byClass, (@=), (^=), ($=), (*=), (~=), (|=), hover, fontFaceSrc, fontStyle, deg, rgba, zIndex, textOverflow, opacity, cursor, transform, transition, easeInOut, cubicBezier, ms, direction, width, em, (@+@), (@-@), (@*), (*@), (@/))
 import CSS.BorderSpec as BorderSpec
+import CSS.DisplaySpec as DisplaySpec
 import CSS.Cursor as Cursor
 import CSS.Flexbox (flex)
 import CSS.FontStyle as FontStyle
@@ -291,4 +292,6 @@ main = do
   log $ "\x1b[32m" <> show count <> " test" <> if count == 1 then "" else "s" <> " passed. These will be migrated to the new format in the future.\x1b[0m\n"
 
   launchAff_ $
-    runSpec [ consoleReporter ] BorderSpec.spec
+    runSpec [ consoleReporter ] do
+      BorderSpec.spec
+      DisplaySpec.spec


### PR DESCRIPTION
**Description of the change**
This pull request adds support for the [`visibility` property](https://developer.mozilla.org/en-US/docs/Web/CSS/visibility). Mostly a direct port from [Clay](https://github.com/sebastiaanvisser/clay/blob/master/src/Clay/Display.hs#L188-L197) with the following caveats in mind:
* `separate` is not a valid value: https://github.com/sebastiaanvisser/clay/issues/225
* `auto` is not a valid value: https://github.com/sebastiaanvisser/clay/issues/224
* `unset` _is_ a valid value: https://github.com/sebastiaanvisser/clay/issues/224

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a link to this PR and your username
- [x] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation in the README and/or documentation directory
- [x] Added a test for the contribution (if applicable)
